### PR TITLE
Add the ability to list the user's events and reminders for the

### DIFF
--- a/src/main/java/tutorpro/logic/Messages.java
+++ b/src/main/java/tutorpro/logic/Messages.java
@@ -20,7 +20,6 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-    
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/tutorpro/logic/Messages.java
+++ b/src/main/java/tutorpro/logic/Messages.java
@@ -21,6 +21,7 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 
+    
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/tutorpro/logic/Messages.java
+++ b/src/main/java/tutorpro/logic/Messages.java
@@ -20,7 +20,6 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-
     
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/tutorpro/logic/commands/ScheduleCommand.java
+++ b/src/main/java/tutorpro/logic/commands/ScheduleCommand.java
@@ -1,21 +1,36 @@
 package tutorpro.logic.commands;
 
+import tutorpro.logic.Messages;
+import tutorpro.logic.commands.exceptions.CommandException;
 import tutorpro.model.Model;
 
 /**
- * Format user's schedule for display.
+ * Format user's schedule for the next specified number of days for display.
+ * If no number of days is specified, displays user's schedule for the next 14 days
+ *
  */
 public class ScheduleCommand extends Command {
 
     public static final String COMMAND_WORD = "schedule";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows user's schedule.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD;
 
     public static final String SHOWING_SCHEDULE_MESSAGE = "Opened schedule.";
+    private int numOfDaysToShow;
+
+    public ScheduleCommand(int n) {
+        this.numOfDaysToShow = n;
+    }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
+        if (numOfDaysToShow < 0) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        model.getTruncatedSchedule(numOfDaysToShow);
         return new CommandResult(SHOWING_SCHEDULE_MESSAGE, false, false, true);
     }
 }

--- a/src/main/java/tutorpro/logic/parser/AddressBookParser.java
+++ b/src/main/java/tutorpro/logic/parser/AddressBookParser.java
@@ -81,7 +81,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case ScheduleCommand.COMMAND_WORD:
-            return new ScheduleCommand();
+            return new ScheduleCommandParser().parse(arguments);
 
         case RemindCommand.COMMAND_WORD:
             return new RemindCommandParser().parse(arguments);

--- a/src/main/java/tutorpro/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/tutorpro/logic/parser/ScheduleCommandParser.java
@@ -1,6 +1,5 @@
 package tutorpro.logic.parser;
 
-import static tutorpro.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import tutorpro.logic.commands.ScheduleCommand;
 import tutorpro.logic.parser.exceptions.ParseException;

--- a/src/main/java/tutorpro/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/tutorpro/logic/parser/ScheduleCommandParser.java
@@ -1,0 +1,31 @@
+package tutorpro.logic.parser;
+
+import static tutorpro.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import tutorpro.logic.commands.ScheduleCommand;
+import tutorpro.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class ScheduleCommandParser implements Parser<ScheduleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ScheduleCommand
+     * and returns a ScheduleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ScheduleCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        int numOfDays;
+        if (trimmedArgs.isEmpty()) {
+            numOfDays = 14;
+        } else {
+            numOfDays = Integer.parseInt(trimmedArgs);
+        }
+
+        return new ScheduleCommand(numOfDays);
+    }
+
+}

--- a/src/main/java/tutorpro/model/AddressBook.java
+++ b/src/main/java/tutorpro/model/AddressBook.java
@@ -108,6 +108,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         schedule.add(r);
     }
 
+    /**
+     * Returns the user's list of reminders and events (their schedule)
+     * @return the user's schedule
+     */
+    public ObservableList<Reminder> getSchedule() {
+        return schedule.getEvents();
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/tutorpro/model/Model.java
+++ b/src/main/java/tutorpro/model/Model.java
@@ -1,7 +1,6 @@
 package tutorpro.model;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 

--- a/src/main/java/tutorpro/model/Model.java
+++ b/src/main/java/tutorpro/model/Model.java
@@ -1,6 +1,8 @@
 package tutorpro.model;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -90,4 +92,15 @@ public interface Model {
      * Adds the given reminder.
      */
     void addReminder(Reminder reminder);
+
+    /**
+     *  Returns the list of reminders and events in the next n days
+     */
+    List<Reminder> getTruncatedSchedule(int n);
+
+    /**
+     * Returns the full list of reminders and events.
+     *
+     */
+    List<Reminder> getSchedule();
 }

--- a/src/main/java/tutorpro/model/ModelManager.java
+++ b/src/main/java/tutorpro/model/ModelManager.java
@@ -3,10 +3,9 @@ package tutorpro.model;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
-import java.util.function.Predicate;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
-
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;

--- a/src/main/java/tutorpro/model/ModelManager.java
+++ b/src/main/java/tutorpro/model/ModelManager.java
@@ -4,8 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.util.function.Predicate;
-import java.util.logging.Logger;
 import java.util.List;
+import java.util.logging.Logger;
+
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;

--- a/src/main/java/tutorpro/model/ModelManager.java
+++ b/src/main/java/tutorpro/model/ModelManager.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.List;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -117,6 +118,18 @@ public class ModelManager implements Model {
         addressBook.addReminder(reminder);
 
     }
+
+    @Override
+    public List<Reminder> getTruncatedSchedule(int n) {
+        return addressBook.getSchedule().subList(0, n);
+
+    }
+
+    @Override
+    public List<Reminder> getSchedule() {
+        return addressBook.getSchedule();
+    }
+
 
     //=========== Filtered Person List Accessors =============================================================
 

--- a/src/test/java/tutorpro/logic/commands/AddCommandTest.java
+++ b/src/test/java/tutorpro/logic/commands/AddCommandTest.java
@@ -165,6 +165,16 @@ public class AddCommandTest {
         public void addReminder(Reminder reminder) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public ObservableList<Reminder> getTruncatedSchedule(int n) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Reminder> getSchedule() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**


### PR DESCRIPTION
specified number of days.

TutorPro currently does not have the ability to display to the user their schedule for the next specified number of days.

Allowing the user to list their schedule for the next specified number of days will make their schedule more efficient to read and allow users to quickly find the information they need.

This commit will implement the function for users to list their truncated schedule.