### PR TITLE
Add window for schedule

### DIFF
--- a/src/main/java/tutorpro/logic/Logic.java
+++ b/src/main/java/tutorpro/logic/Logic.java
@@ -10,6 +10,7 @@ import tutorpro.logic.parser.exceptions.ParseException;
 import tutorpro.model.Model;
 import tutorpro.model.ReadOnlyAddressBook;
 import tutorpro.model.person.Person;
+import tutorpro.model.schedule.Reminder;
 
 /**
  * API of the Logic component
@@ -48,4 +49,9 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns an unmodifiable view of the user's schedule
+     */
+    ObservableList<Reminder> getTruncatedSchedule();
 }

--- a/src/main/java/tutorpro/logic/LogicManager.java
+++ b/src/main/java/tutorpro/logic/LogicManager.java
@@ -16,6 +16,7 @@ import tutorpro.logic.parser.exceptions.ParseException;
 import tutorpro.model.Model;
 import tutorpro.model.ReadOnlyAddressBook;
 import tutorpro.model.person.Person;
+import tutorpro.model.schedule.Reminder;
 import tutorpro.storage.Storage;
 
 /**
@@ -84,5 +85,11 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public ObservableList<Reminder> getTruncatedSchedule() {
+        ObservableList<Reminder> list = (ObservableList<Reminder>) model.getTruncatedSchedule(14);
+        return list;
     }
 }

--- a/src/main/java/tutorpro/logic/commands/ScheduleCommand.java
+++ b/src/main/java/tutorpro/logic/commands/ScheduleCommand.java
@@ -33,4 +33,5 @@ public class ScheduleCommand extends Command {
         model.getTruncatedSchedule(numOfDaysToShow);
         return new CommandResult(SHOWING_SCHEDULE_MESSAGE, false, false, true);
     }
+
 }

--- a/src/main/java/tutorpro/logic/parser/EventCommandParser.java
+++ b/src/main/java/tutorpro/logic/parser/EventCommandParser.java
@@ -37,7 +37,7 @@ public class EventCommandParser implements Parser<EventCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TIME, PREFIX_HOURS);
         String name = argMultimap.getValue(PREFIX_NAME).get();
         LocalDateTime time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get());
-        long hours = ParserUtil.parseHours(argMultimap.getValue(PREFIX_HOURS).get());
+        float hours = ParserUtil.parseHours(argMultimap.getValue(PREFIX_HOURS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Event event = new Event(name, time, hours, "", new HashSet<>(), tagList);

--- a/src/main/java/tutorpro/logic/parser/ParserUtil.java
+++ b/src/main/java/tutorpro/logic/parser/ParserUtil.java
@@ -183,13 +183,14 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code String hours} into a {@code long}.
+     * Parses {@code String hours} into a {@code float}.
      */
-    public static long parseHours(String hours) throws ParseException {
+    public static float parseHours(String hours) throws ParseException {
         try {
             return Long.parseLong(hours);
         } catch (DateTimeParseException e) {
             throw new ParseException("Hours should be a number.");
         }
     }
+
 }

--- a/src/main/java/tutorpro/model/schedule/Event.java
+++ b/src/main/java/tutorpro/model/schedule/Event.java
@@ -14,12 +14,13 @@ import tutorpro.model.tag.Tag;
 public class Event extends Reminder {
 
     public static final String END_BEFORE_START = "Events cannot end before they start.";
-    private final long duration;
+
+    private final float duration;
 
     /**
      * Every field must be present and not null.
      */
-    public Event(String name, LocalDateTime startTime, long duration, String notes, Set<Person> people, Set<Tag> tags) {
+    public Event(String name, LocalDateTime startTime, float duration, String notes, Set<Person> people, Set<Tag> tags) {
         super(name, startTime, notes, people, tags);
         CollectionUtil.requireAllNonNull(duration);
         this.duration = duration;
@@ -28,12 +29,13 @@ public class Event extends Reminder {
     /**
      * Returns the duration of the event in hours.
      */
-    public long getDuration() {
+    public float getDuration() {
         return duration;
     }
 
     public LocalDateTime getEndTime() {
-        return getTime().plusHours(duration);
+        long durationInMinutes = (long) duration * 60;
+        return getTime().plusMinutes(durationInMinutes);
     }
 
     @Override

--- a/src/main/java/tutorpro/model/schedule/Reminder.java
+++ b/src/main/java/tutorpro/model/schedule/Reminder.java
@@ -6,9 +6,12 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import javafx.scene.layout.Region;
 import tutorpro.commons.util.CollectionUtil;
 import tutorpro.model.person.Person;
 import tutorpro.model.tag.Tag;
+import tutorpro.ui.ReminderCard;
+import tutorpro.ui.UiPart;
 
 /**
  * A class representing a Reminder.
@@ -71,5 +74,8 @@ public class Reminder {
 
     public int hashCode() {
         return Objects.hash(name, time, notes, people, tags);
+    }
+    public UiPart<Region> getCard(int displayIndex) {
+        return new ReminderCard(this, displayIndex);
     }
 }

--- a/src/main/java/tutorpro/storage/JsonAdaptedReminder.java
+++ b/src/main/java/tutorpro/storage/JsonAdaptedReminder.java
@@ -1,0 +1,110 @@
+package tutorpro.storage;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import tutorpro.commons.exceptions.IllegalValueException;
+import tutorpro.model.person.Name;
+import tutorpro.model.person.Person;
+import tutorpro.model.schedule.Reminder;
+import tutorpro.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Person}.
+ */
+class JsonAdaptedReminder {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Reminder's %s field is missing!";
+
+    protected final String name;
+    protected final LocalDateTime time;
+    protected final String notes;
+    protected final List<JsonAdaptedPerson> people = new ArrayList<>();
+    protected final List<JsonAdaptedTag> tags = new ArrayList<>();
+
+
+
+    /**
+     * Constructs a {@code JsonAdaptedPerson} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedReminder(@JsonProperty("name") String name, @JsonProperty("time") LocalDateTime time,
+                             @JsonProperty("notes") String notes, @JsonProperty("people") List<JsonAdaptedPerson> people,
+                             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+        this.name = name;
+        this.time = time;
+        this.notes = notes;
+        if (people != null) {
+            this.people.addAll(people);
+        }
+        if (tags != null) {
+            this.tags.addAll(tags);
+        }
+    }
+
+    /**
+     * Converts a given {@code Person} into this class for Jackson use.
+     */
+    public JsonAdaptedReminder(Reminder source) {
+        name = source.getName();
+        time = source.getTime();
+        notes = source.getNotes();
+
+        people.addAll(source.getPeople().stream()
+                .map(JsonAdaptedPerson::new)
+                .collect(Collectors.toList()));
+
+        tags.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted person object into the model's {@code Reminder} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted reminder.
+     */
+    public Reminder toModelType() throws IllegalValueException {
+        final List<Person> reminderPeople = new ArrayList<>();
+        for (JsonAdaptedPerson person : people) {
+            reminderPeople.add(person.toModelType());
+        }
+
+        final List<Tag> reminderTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tags) {
+            reminderTags.add(tag.toModelType());
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final String modelName = name;
+
+        if (time == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, LocalDateTime.class.getSimpleName()));
+        }
+        final LocalDateTime modelTime = time;
+
+        if (notes == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, String.class.getSimpleName()));
+        }
+
+        final String modelNotes = notes;
+
+        final Set<Person> modelPeople = new HashSet<>(reminderPeople);
+
+        final Set<Tag> modelTags = new HashSet<>(reminderTags);
+
+        return new Reminder(modelName, modelTime, modelNotes, modelPeople, modelTags);
+    }
+}

--- a/src/main/java/tutorpro/ui/MainWindow.java
+++ b/src/main/java/tutorpro/ui/MainWindow.java
@@ -160,6 +160,7 @@ public class MainWindow extends UiPart<Stage> {
     public void handleSchedule() {
         if (!scheduleWindow.isShowing()) {
             scheduleWindow.show();
+            scheduleWindow.fillInnerParts();
         } else {
             scheduleWindow.focus();
         }

--- a/src/main/java/tutorpro/ui/ReminderCard.java
+++ b/src/main/java/tutorpro/ui/ReminderCard.java
@@ -1,0 +1,65 @@
+package tutorpro.ui;
+
+import java.util.Comparator;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import tutorpro.model.schedule.Reminder;
+
+/**
+ * An UI component that displays information of a {@code Person}.
+ */
+public class ReminderCard extends UiPart<Region> {
+
+    private static final String FXML = "PersonListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Reminder reminder;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+    @FXML
+    private Label time;
+    @FXML
+    private Label notes;
+    @FXML
+    private Label people;
+    @FXML
+    private FlowPane tags;
+
+    /**
+     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     */
+    public ReminderCard(Reminder reminder, int displayedIndex) {
+        super(FXML);
+        this.reminder = reminder;
+        id.setText(displayedIndex + ". ");
+        name.setText(reminder.getName());
+        time.setText(reminder.getTime().toString());
+        notes.setText(reminder.getNotes());
+
+        String listOfPeople = " ";
+        for (int i = 0; i < reminder.getPeople().size(); i++) {
+            listOfPeople = i + 1 + ". " + reminder.getPeople().toArray()[i].toString() + "\n";
+        }
+        people.setText(listOfPeople);
+
+        reminder.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+}

--- a/src/main/java/tutorpro/ui/ReminderListPanel.java
+++ b/src/main/java/tutorpro/ui/ReminderListPanel.java
@@ -1,0 +1,49 @@
+package tutorpro.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import tutorpro.commons.core.LogsCenter;
+import tutorpro.model.schedule.Reminder;
+
+/**
+ * Panel containing the list of reminders.
+ */
+public class ReminderListPanel extends UiPart<Region> {
+    private static final String FXML = "ReminderListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ReminderListPanel.class);
+
+    @FXML
+    private ListView<Reminder> reminderListView;
+
+    /**
+     * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
+     */
+    public ReminderListPanel(ObservableList<Reminder> reminderList) {
+        super(FXML);
+        reminderListView.setItems(reminderList);
+        reminderListView.setCellFactory(listView -> new ReminderListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
+     */
+    class ReminderListViewCell extends ListCell<Reminder> {
+        @Override
+        protected void updateItem(Reminder reminder, boolean empty) {
+            super.updateItem(reminder, empty);
+
+            if (empty || reminder == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(reminder.getCard(getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/java/tutorpro/ui/ScheduleWindow.java
+++ b/src/main/java/tutorpro/ui/ScheduleWindow.java
@@ -9,8 +9,11 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
+import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+import tutorpro.commons.core.GuiSettings;
 import tutorpro.commons.core.LogsCenter;
+import tutorpro.logic.Logic;
 
 /**
  * Window showing the Schedule.
@@ -22,12 +25,23 @@ public class ScheduleWindow extends UiPart<Stage> {
 
     private static final Logger logger = LogsCenter.getLogger(ScheduleWindow.class);
     private static final String FXML = "ScheduleWindow.fxml";
+    private Logic logic;
 
+    // Independent Ui parts residing in this Ui container
+    private ReminderListPanel reminderListPanel;
+
+    private ResultDisplay resultDisplay;
     @FXML
     private Button copyButton;
 
     @FXML
     private Label scheduleMessage;
+
+    @FXML
+    private StackPane reminderListPanelPlaceholder;
+
+    @FXML
+    private StackPane resultDisplayPlaceholder;
 
     /**
      * Creates a new ScheduleWindow.
@@ -70,6 +84,29 @@ public class ScheduleWindow extends UiPart<Stage> {
         getRoot().centerOnScreen();
     }
 
+    /**
+     * Fills up all the placeholders of this window.
+     */
+    void fillInnerParts() {
+        reminderListPanel = new ReminderListPanel(logic.getTruncatedSchedule());
+        reminderListPanelPlaceholder.getChildren().add(reminderListPanel.getRoot());
+
+        resultDisplay = new ResultDisplay();
+        resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
+
+    }
+
+//    /**
+//     * Sets the default size based on {@code guiSettings}.
+//     */
+//    private void setWindowDefaultSize(GuiSettings guiSettings) {
+//        primaryStage.setHeight(guiSettings.getWindowHeight());
+//        primaryStage.setWidth(guiSettings.getWindowWidth());
+//        if (guiSettings.getWindowCoordinates() != null) {
+//            primaryStage.setX(guiSettings.getWindowCoordinates().getX());
+//            primaryStage.setY(guiSettings.getWindowCoordinates().getY());
+//        }
+//    }
     /**
      * Returns true if the schedule window is currently being shown.
      */

--- a/src/main/resources/view/ReminderCard.fxml
+++ b/src/main/resources/view/ReminderCard.fxml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+            </HBox>
+            <FlowPane fx:id="tags" />
+            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/ReminderListPanel.fxml
+++ b/src/main/resources/view/ReminderListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="reminderListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/main/resources/view/ScheduleWindow.css
+++ b/src/main/resources/view/ScheduleWindow.css
@@ -1,18 +1,11 @@
-/*#copyButton, #scheduleMessage {*/
-/*    -fx-text-fill: white;*/
-/*}*/
+#filterField, #scheduleListPanel, #personWebpage {
+    -fx-effect: innershadow(gaussian, black, 10, 0, 0, 0);
+}
 
-/*#copyButton {*/
-/*    -fx-background-color: dimgray;*/
-/*}*/
-
-/*#copyButton:hover {*/
-/*    -fx-background-color: gray;*/
-/*}*/
-
-/*#copyButton:armed {*/
-/*    -fx-background-color: darkgray;*/
-/*}*/
+#resultDisplay .content {
+    -fx-background-color: transparent, #383838, transparent, #383838;
+    -fx-background-radius: 0;
+}
 
 #scheduleMessageContainer {
     -fx-background-color: derive(#1d1d1d, 20%);

--- a/src/main/resources/view/ScheduleWindow.fxml
+++ b/src/main/resources/view/ScheduleWindow.fxml
@@ -3,9 +3,9 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
-<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
@@ -27,11 +27,19 @@
                             <Insets right="5.0" />
                         </VBox.margin>
                     </Label>
-<!--                    <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">-->
-<!--                        <HBox.margin>-->
-<!--                            <Insets left="5.0" />-->
-<!--                        </HBox.margin>-->
-<!--                    </Button>-->
+                    <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
+                               minHeight="100" prefHeight="100" maxHeight="100">
+                        <padding>
+                            <Insets top="5" right="10" bottom="5" left="10" />
+                        </padding>
+                    </StackPane>
+
+                    <VBox fx:id="reminderList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+                        <padding>
+                            <Insets top="10" right="10" bottom="10" left="10" />
+                        </padding>
+                        <StackPane fx:id="reminderListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                    </VBox>
                 </children>
                 <opaqueInsets>
                     <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />


### PR DESCRIPTION
Currently, the user's schedule is not displayed in a separate window. This may cause inconvenience if the user wants to view both their student list and their schedule at the same time.

This commit creates a separate window for the user's schedule to be displayed on.